### PR TITLE
Use `OutOfBoundsException` instead of returning `null`

### DIFF
--- a/src/ArrayInterface.php
+++ b/src/ArrayInterface.php
@@ -6,6 +6,7 @@ namespace Boesing\TypedArrays;
 
 use Countable;
 use IteratorAggregate;
+use OutOfBoundsException;
 
 /**
  * @internal
@@ -23,14 +24,16 @@ interface ArrayInterface extends IteratorAggregate, Countable
     public function contains($element): bool;
 
     /**
-     * @psalm-return TValue|null
+     * @psalm-return TValue
      * @psalm-mutation-free
+     * @throws OutOfBoundsException if there are no values available.
      */
     public function first();
 
     /**
-     * @psalm-return TValue|null
+     * @psalm-return TValue
      * @psalm-mutation-free
+     * @throws OutOfBoundsException if there are no values available.
      */
     public function last();
 

--- a/src/Array_.php
+++ b/src/Array_.php
@@ -6,6 +6,7 @@ namespace Boesing\TypedArrays;
 
 use ArrayIterator;
 use DateTimeInterface;
+use OutOfBoundsException;
 use Traversable;
 use Webmozart\Assert\Assert;
 
@@ -59,8 +60,8 @@ abstract class Array_ implements ArrayInterface
      */
     public function first()
     {
-        if ($this->data === []) {
-            return null;
+        if ($this->isEmpty()) {
+            throw new OutOfBoundsException('There are no values available.');
         }
 
         return reset($this->data);
@@ -71,8 +72,8 @@ abstract class Array_ implements ArrayInterface
      */
     public function last()
     {
-        if ($this->data === []) {
-            return null;
+        if ($this->isEmpty()) {
+            throw new OutOfBoundsException('There are no values available.');
         }
 
         return end($this->data);

--- a/src/Map.php
+++ b/src/Map.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Boesing\TypedArrays;
 
+use OutOfBoundsException;
 use Webmozart\Assert\Assert;
 
 use function array_diff_ukey;
 use function array_filter;
 use function array_intersect_ukey;
+use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -17,6 +19,7 @@ use function array_uintersect;
 use function array_uintersect_uassoc;
 use function array_values;
 use function asort;
+use function sprintf;
 use function uasort;
 use function usort;
 
@@ -138,7 +141,11 @@ abstract class Map extends Array_ implements MapInterface
      */
     public function get($key)
     {
-        return $this->data[$key] ?? null;
+        if (! array_key_exists($key, $this->data)) {
+            throw new OutOfBoundsException(sprintf('There is no value stored for provided key: %s', (string) $key));
+        }
+
+        return $this->data[$key];
     }
 
     public function intersect(MapInterface $other, ?callable $valueComparator = null): MapInterface

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Boesing\TypedArrays;
 
+use OutOfBoundsException;
+
 /**
  * @template         TValue
  * @template-extends ArrayInterface<string,TValue>
@@ -91,7 +93,8 @@ interface MapInterface extends ArrayInterface
 
     /**
      * @psalm-param string $key
-     * @psalm-return TValue|null
+     * @psalm-return TValue
+     * @throws OutOfBoundsException if key does not exist.
      * @psalm-mutation-free
      */
     public function get($key);

--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -11,6 +11,7 @@ use Webmozart\Assert\Assert;
 use function array_combine;
 use function array_fill;
 use function array_filter;
+use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -23,6 +24,7 @@ use function hash;
 use function is_callable;
 use function serialize;
 use function sort;
+use function sprintf;
 use function usort;
 
 use const SORT_NATURAL;
@@ -76,7 +78,11 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
      */
     public function at(int $position)
     {
-        return $this->data[$position] ?? null;
+        if (! array_key_exists($position, $this->data)) {
+            throw new OutOfBoundsException(sprintf('There is no value stored in that position: %d', $position));
+        }
+
+        return $this->data[$position];
     }
 
     public function sort(?callable $callback = null): OrderedListInterface
@@ -187,7 +193,11 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
 
         foreach ($instance->data as $value) {
             $identifier = $unificationIdentifierGenerator($value);
-            $unique     = $unified->get($identifier) ?? $value;
+            try {
+                $unique = $unified->get($identifier);
+            } catch (OutOfBoundsException $exception) {
+                $unique = $value;
+            }
 
             if ($callback) {
                 $unique = $callback($unique, $value);

--- a/src/OrderedListInterface.php
+++ b/src/OrderedListInterface.php
@@ -20,7 +20,8 @@ interface OrderedListInterface extends ArrayInterface
     public function add($element): OrderedListInterface;
 
     /**
-     * @psalm-return TValue|null
+     * @psalm-return TValue
+     * @throws OutOfBoundsException If position does not exist.
      * @psalm-mutation-free
      */
     public function at(int $position);

--- a/tests/GenericMapTest.php
+++ b/tests/GenericMapTest.php
@@ -9,6 +9,7 @@ use Boesing\TypedArrays\Asset\GenericObject;
 use DateTimeImmutable;
 use Generator;
 use Lcobucci\Clock\FrozenClock;
+use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -458,5 +459,12 @@ final class GenericMapTest extends TestCase
             $map1->intersectUserAssoc($map2, $valueComparator, $keyComparator)
                 ->toNativeArray()
         );
+    }
+
+    public function testGetThrowsOutOfBoundsExceptionWhenKeyDoesNotExist(): void
+    {
+        $map = new GenericMap([]);
+        $this->expectException(OutOfBoundsException::class);
+        $map->get('foo');
     }
 }

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -202,7 +202,8 @@ final class GenericOrderedListTest extends TestCase
     {
         $list = new GenericOrderedList([]);
 
-        self::assertNull($list->at(0));
+        $this->expectException(OutOfBoundsException::class);
+        $list->at(0);
     }
 
     /**
@@ -631,11 +632,18 @@ final class GenericOrderedListTest extends TestCase
         self::assertEquals($object2, $list->last());
     }
 
-    public function testFirstAndLastReturnNullOnEmptyList(): void
+    public function testFirstThrowsOutOfBoundsExceptionWhenListIsEmpty(): void
     {
         $list = new GenericOrderedList([]);
-        self::assertNull($list->first());
-        self::assertNull($list->last());
+        $this->expectException(OutOfBoundsException::class);
+        $list->first();
+    }
+
+    public function testLastThrowsOutOfBoundsExceptionWhenListIsEmpty(): void
+    {
+        $list = new GenericOrderedList([]);
+        $this->expectException(OutOfBoundsException::class);
+        $list->last();
     }
 
     public function testContainsDoesExactMatch(): void


### PR DESCRIPTION
If `null` is being stored in a map or list, there is no way to know if the value is `null` or if the value does not exist.