### PR TITLE
Json serialization

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -362,4 +362,13 @@ abstract class Map extends Array_ implements MapInterface
 
         return $instance;
     }
+
+    public function jsonSerialize(): ?array
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        return $this->data;
+    }
 }

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Boesing\TypedArrays;
 
+use JsonSerializable;
 use OutOfBoundsException;
 
 /**
@@ -11,7 +12,7 @@ use OutOfBoundsException;
  * @template         TValue
  * @template-extends ArrayInterface<TKey,TValue>
  */
-interface MapInterface extends ArrayInterface
+interface MapInterface extends ArrayInterface, JsonSerializable
 {
     /**
      * @psalm-param  Closure(TValue,TKey):bool $callback

--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -349,8 +349,19 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
     /**
      * @psalm-return list<TValue>
      */
+    public function toNativeArray(): array
+    {
+        $data = $this->data;
+        Assert::isList($data);
+
+        return $data;
+    }
+
+    /**
+     * @psalm-return list<TValue>
+     */
     public function jsonSerialize(): array
     {
-        return array_values($this->data);
+        return $this->toNativeArray();
     }
 }

--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -345,4 +345,12 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
 
         return $groups;
     }
+
+    /**
+     * @psalm-return list<TValue>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_values($this->data);
+    }
 }

--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -175,7 +175,7 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
     {
         /** @psalm-suppress MissingClosureParamType */
         return $this->filter(
-            static function (/** @param TValue $value */ $value) use ($element): bool {
+            static function ($value) use ($element): bool {
                 return $value !== $element;
             }
         );

--- a/src/OrderedListInterface.php
+++ b/src/OrderedListInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Boesing\TypedArrays;
 
 use InvalidArgumentException;
+use JsonSerializable;
 use OutOfBoundsException;
 
 /**
@@ -12,7 +13,7 @@ use OutOfBoundsException;
  * @template-extends ArrayInterface<int,TValue>
  * @psalm-immutable
  */
-interface OrderedListInterface extends ArrayInterface
+interface OrderedListInterface extends ArrayInterface, JsonSerializable
 {
     /**
      * @psalm-param TValue $element

--- a/tests/GenericMapTest.php
+++ b/tests/GenericMapTest.php
@@ -16,9 +16,12 @@ use Webmozart\Assert\Assert;
 
 use function array_map;
 use function in_array;
+use function json_encode;
 use function strlen;
 use function strnatcmp;
 use function trim;
+
+use const JSON_THROW_ON_ERROR;
 
 final class GenericMapTest extends TestCase
 {
@@ -772,5 +775,23 @@ final class GenericMapTest extends TestCase
         self::assertTrue($sliced->has('foo'));
         self::assertTrue($sliced->has('bar'));
         self::assertFalse($sliced->has('baz'));
+    }
+
+    public function testJsonSerializeOnEmptyMapReturnsNull(): void
+    {
+        $instance = new GenericMap();
+        self::assertEquals('null', json_encode($instance, JSON_THROW_ON_ERROR));
+    }
+
+    public function testJsonSerializeWillGenerateMapOfEntries(): void
+    {
+        $list = new GenericMap([
+            'one' => 1,
+            'two' => 2,
+            'foo' => 'foo',
+            'three' => 3,
+        ]);
+
+        self::assertEquals('{"one":1,"two":2,"foo":"foo","three":3}', json_encode($list, JSON_THROW_ON_ERROR));
     }
 }

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -19,11 +19,14 @@ use function array_fill;
 use function array_map;
 use function chr;
 use function in_array;
+use function json_encode;
 use function md5;
 use function mt_rand;
 use function spl_object_hash;
 use function strlen;
 use function strnatcmp;
+
+use const JSON_THROW_ON_ERROR;
 
 final class GenericOrderedListTest extends TestCase
 {
@@ -1126,5 +1129,37 @@ final class GenericOrderedListTest extends TestCase
             },
             false,
         ];
+    }
+
+    public function testJsonSerializeOnEmptyListReturnsEmptyList(): void
+    {
+        $instance = new GenericOrderedList();
+        self::assertEquals('[]', json_encode($instance, JSON_THROW_ON_ERROR));
+    }
+
+    public function testJsonSerializeWillGenerateListOfEntries(): void
+    {
+        $list = new GenericOrderedList([
+            1,
+            2,
+            'foo',
+            3,
+        ]);
+
+        self::assertEquals('[1,2,"foo",3]', json_encode($list, JSON_THROW_ON_ERROR));
+    }
+
+    public function testRemovalOfEntryWillStillJsonSerializeListOfEntries(): void
+    {
+        $list = new GenericOrderedList([
+            1,
+            2,
+            'foo',
+            3,
+        ]);
+
+        $list = $list->removeElement(2);
+
+        self::assertEquals('[1,"foo",3]', json_encode($list, JSON_THROW_ON_ERROR));
     }
 }


### PR DESCRIPTION
This will ensure proper JSON serialization as empty maps supposed to become `null` to keep type-safety.

See https://3v4l.org/Itfsj for more insights.