### PR TITLE
qa: introduce php forward compatibility

### DIFF
--- a/.github/workflows/php-forward-compatibility.yml
+++ b/.github/workflows/php-forward-compatibility.yml
@@ -1,0 +1,32 @@
+name: "PHP forward compatibility"
+
+on:
+  schedule:
+    # Execute weekly checks
+    - cron: "0 14 * * 1"
+
+jobs:
+  qa:
+    continue-on-error: true
+    name: Unit tests
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          tools: "composer:v2"
+        env:
+          update: true
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          dependency-versions: "latest"
+          composer-options: "--ignore-platform-req=php"
+
+      - name: Run unit tests
+        run: "vendor/bin/phpunit"


### PR DESCRIPTION
Having weekly checks for upcoming PHP versions will help to prepare this library to support upcoming PHP versions as soon as possible