### PR TITLE
bugfix: only call callback for duplicates rather than all entries

### DIFF
--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -221,12 +221,12 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
             $identifier = $unificationIdentifierGenerator($value);
             try {
                 $unique = $unified->get($identifier);
+
+                if ($callback) {
+                    $unique = $callback($unique, $value);
+                }
             } catch (OutOfBoundsException $exception) {
                 $unique = $value;
-            }
-
-            if ($callback) {
-                $unique = $callback($unique, $value);
             }
 
             $unified = $unified->put($identifier, $unique);

--- a/src/OrderedListInterface.php
+++ b/src/OrderedListInterface.php
@@ -82,7 +82,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
 
     /**
      * @psalm-param (callable(TValue):non-empty-string)|null $unificationIdentifierGenerator
-     * @psalm-param (callable(TValue,TValue):TValue)|null  $callback
+     * @psalm-param (callable(TValue,TValue):TValue)|null $callback This callback is called for duplications only.
      * @psalm-return OrderedListInterface<TValue>
      */
     public function unify(

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -20,8 +20,10 @@ use Webmozart\Assert\Assert;
 use function array_fill;
 use function array_map;
 use function array_reverse;
+use function assert;
 use function chr;
 use function in_array;
+use function is_int;
 use function json_encode;
 use function md5;
 use function mt_rand;
@@ -541,6 +543,24 @@ final class GenericOrderedListTest extends TestCase
             $callbackCalled = true;
         });
         self::assertTrue($callbackCalled);
+    }
+
+    public function testCallbackOnDeduplicationIsOnlyCalledForDuplicates(): void
+    {
+        $list           = new GenericOrderedList([1, 2, 3, 1, 1, 1]);
+        $callbackCalled = 0;
+
+        /**
+         * @psalm-suppress UnusedMethodCall
+         */
+        $list->unify(null, static function (int $duplicate, int $number) use (&$callbackCalled): int {
+            self::assertEquals($duplicate, $number);
+            assert(is_int($callbackCalled));
+            $callbackCalled++;
+
+            return $number;
+        });
+        self::assertEquals(3, $callbackCalled);
     }
 
     /**


### PR DESCRIPTION
fixes #74 