### PR TITLE
Feature: Add `MapInterface#values` as an alias for `MapInterface#toOrderedList`

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -150,6 +150,11 @@ abstract class Map extends Array_ implements MapInterface
 
         return new GenericOrderedList($keys);
     }
+    
+    public function values(): OrderedListInterface
+    {
+        return $this->toOrderedList();
+    }
 
     public function put($key, $value): MapInterface
     {

--- a/src/Map.php
+++ b/src/Map.php
@@ -150,7 +150,7 @@ abstract class Map extends Array_ implements MapInterface
 
         return new GenericOrderedList($keys);
     }
-    
+
     public function values(): OrderedListInterface
     {
         return $this->toOrderedList();

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -86,7 +86,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * @psalm-return OrderedListInterface<TKey>
      */
     public function keys(): OrderedListInterface;
-    
+
     /**
      * @psalm-return OrderedListInterface<TValue>
      */

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -88,7 +88,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
     public function keys(): OrderedListInterface;
     
     /**
-     * @psalm-return OrderedListInterface<TKey>
+     * @psalm-return OrderedListInterface<TValue>
      */
     public function values(): OrderedListInterface;
 

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -86,6 +86,11 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * @psalm-return OrderedListInterface<TKey>
      */
     public function keys(): OrderedListInterface;
+    
+    /**
+     * @psalm-return OrderedListInterface<TKey>
+     */
+    public function values(): OrderedListInterface;
 
     /**
      * @psalm-param TKey   $key


### PR DESCRIPTION
This will add a `values()` alias to Map to further improve the API so there is a method beside `keys()`.
This is only a forward to `toOrderedList` without sorting the values.