### PR TITLE
Feature: add `OrderedListInterface#prepend`

### DIFF
--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -17,6 +17,7 @@ use function array_reverse;
 use function array_slice;
 use function array_udiff;
 use function array_uintersect;
+use function array_unshift;
 use function array_values;
 use function assert;
 use function hash;
@@ -407,5 +408,13 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         }
 
         return null;
+    }
+
+    public function prepend($value): OrderedListInterface
+    {
+        $instance = clone $this;
+        array_unshift($instance->data, $value);
+
+        return $instance;
     }
 }

--- a/src/OrderedListInterface.php
+++ b/src/OrderedListInterface.php
@@ -166,4 +166,12 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * @return 0|positive-int|null
      */
     public function findFirstMatchingIndex(callable $filter): ?int;
+
+    /**
+     * Adds an item at the beginning of the list.
+     *
+     * @param TValue $value
+     * @return OrderedListInterface<TValue>
+     */
+    public function prepend($value): self;
 }

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -1445,4 +1445,16 @@ final class GenericOrderedListTest extends TestCase
 
         self::assertNull($list->findFirstMatchingIndex(static fn (int $value) => $value % 2 !== 0));
     }
+
+    public function testWillPrependValueToTheList(): void
+    {
+        /** @var OrderedListInterface<non-empty-string> $list */
+        $list = new GenericOrderedList([
+            'bar',
+            'baz',
+        ]);
+
+        $list = $list->prepend('foo');
+        self::assertSame(['foo', 'bar', 'baz'], $list->toNativeArray());
+    }
 }


### PR DESCRIPTION
This provides the ability of adding a value in front of the ordered list

fixes #119 