### PR TITLE
Feature: add `OrderedListInterface#limit($length)`

### DIFF
--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -280,6 +280,11 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         return $instance;
     }
 
+    public function limit(int $length): OrderedListInterface
+    {
+        return $this->slice(0, $length);
+    }
+
     public function find(callable $callback)
     {
         foreach ($this->data as $value) {

--- a/src/OrderedListInterface.php
+++ b/src/OrderedListInterface.php
@@ -104,6 +104,12 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
     public function slice(int $offset, ?int $length = null): OrderedListInterface;
 
     /**
+     * @param positive-int $length
+     * @psalm-return OrderedListInterface<TValue>
+     */
+    public function limit(int $length): OrderedListInterface;
+
+    /**
      * @psalm-param pure-callable(TValue):bool $callback
      * @psalm-return TValue
      * @throws OutOfBoundsException if value could not be found with provided callback.


### PR DESCRIPTION
Adding `OrderedListInterface#limit($length)` as an alias of `OrderedListInterface#slice(0, $length)`

fixes #98 