### PR TITLE
Remove purity of provided callbacks

### DIFF
--- a/src/ArrayInterface.php
+++ b/src/ArrayInterface.php
@@ -51,14 +51,14 @@ interface ArrayInterface extends IteratorAggregate, Countable
     /**
      * Tests if all elements satisfy the given predicate.
      *
-     * @psalm-param pure-callable(TValue):bool $callback
+     * @psalm-param callable(TValue):bool $callback
      */
     public function allSatisfy(callable $callback): bool;
 
     /**
      * Tests for the existence of an element that satisfies the given predicate.
      *
-     * @psalm-param pure-callable(TValue):bool $callback
+     * @psalm-param callable(TValue):bool $callback
      */
     public function exists(callable $callback): bool;
 
@@ -71,8 +71,8 @@ interface ArrayInterface extends IteratorAggregate, Countable
 
     /**
      * @template TReducedValue
-     * @param pure-callable(TReducedValue,TValue):TReducedValue $callback
-     * @param TReducedValue                                     $initial
+     * @param callable(TReducedValue,TValue):TReducedValue $callback
+     * @param TReducedValue                                $initial
      * @return TReducedValue
      */
     public function reduce(callable $callback, $initial);

--- a/src/Array_.php
+++ b/src/Array_.php
@@ -107,6 +107,10 @@ abstract class Array_ implements ArrayInterface
     public function allSatisfy(callable $callback): bool
     {
         foreach ($this->data as $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if (! $callback($value)) {
                 return false;
             }
@@ -118,6 +122,10 @@ abstract class Array_ implements ArrayInterface
     public function exists(callable $callback): bool
     {
         foreach ($this->data as $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if ($callback($value)) {
                 return true;
             }
@@ -131,7 +139,11 @@ abstract class Array_ implements ArrayInterface
     {
         $instance = clone $this;
 
-        /** @psalm-suppress MixedReturnStatement The return value of the callback ensures the return type. */
+        /**
+         * @psalm-suppress MixedReturnStatement The return value of the callback ensures the return type.
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         return array_reduce($instance->data, $callback, $initial);
     }
 }

--- a/src/Map.php
+++ b/src/Map.php
@@ -70,6 +70,10 @@ abstract class Map extends Array_ implements MapInterface
             return $instance;
         }
 
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         uasort($data, $callback);
         $instance->data = $data;
 
@@ -84,10 +88,14 @@ abstract class Map extends Array_ implements MapInterface
 
         /**
          * @psalm-var array<TKey,TValue> $diff1
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
          */
         $diff1 = array_diff_ukey($instance->data, $otherData, $keyComparator);
         /**
          * @psalm-var array<TKey,TValue> $diff2
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
          */
         $diff2  = array_diff_ukey($otherData, $instance->data, $keyComparator);
         $merged = array_merge(
@@ -101,7 +109,7 @@ abstract class Map extends Array_ implements MapInterface
     }
 
     /**
-     * @psalm-return pure-callable(TKey,TKey):int
+     * @psalm-return callable(TKey,TKey):int
      */
     private function keyComparator(): callable
     {
@@ -118,6 +126,10 @@ abstract class Map extends Array_ implements MapInterface
 
         $data = $this->data;
 
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         usort($data, $sorter);
 
         return new GenericOrderedList($data);
@@ -128,6 +140,10 @@ abstract class Map extends Array_ implements MapInterface
         $instance = clone $this;
         $filtered = [];
         foreach ($instance->data as $key => $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if (! $callback($value, $key)) {
                 continue;
             }
@@ -179,8 +195,8 @@ abstract class Map extends Array_ implements MapInterface
 
     /**
      * @psalm-param MapInterface<TKey,TValue> $other
-     * @psalm-param (pure-callable(TValue,TValue):int)|null $valueComparator
-     * @psalm-param (pure-callable(TKey,TKey):int)|null $keyComparator
+     * @psalm-param (callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param (callable(TKey,TKey):int)|null $keyComparator
      * @psalm-return array<TKey,TValue>
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
      */
@@ -189,6 +205,8 @@ abstract class Map extends Array_ implements MapInterface
         if ($valueComparator && $keyComparator) {
             /**
              * @psalm-var array<TKey,TValue> $intersection
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
              */
             $intersection = array_uintersect_uassoc(
                 $this->data,
@@ -203,6 +221,8 @@ abstract class Map extends Array_ implements MapInterface
         if ($keyComparator) {
             /**
              * @psalm-var array<TKey,TValue> $intersection
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
              */
             $intersection = array_intersect_ukey($this->data, $other->toNativeArray(), $keyComparator);
 
@@ -215,6 +235,8 @@ abstract class Map extends Array_ implements MapInterface
 
         /**
          * @psalm-var array<TKey,TValue> $intersection
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
          */
         $intersection = array_uintersect($this->data, $other->toNativeArray(), $valueComparator);
 
@@ -252,6 +274,8 @@ abstract class Map extends Array_ implements MapInterface
     {
         /**
          * @psalm-var array<TKey,TValue> $diff1
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
          */
         $diff1 = array_udiff(
             $this->toNativeArray(),
@@ -261,6 +285,8 @@ abstract class Map extends Array_ implements MapInterface
 
         /**
          * @psalm-var array<TKey,TValue> $diff2
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
          */
         $diff2 = array_udiff(
             $other->toNativeArray(),
@@ -303,13 +329,17 @@ abstract class Map extends Array_ implements MapInterface
 
     /**
      * @template     TNewValue
-     * @psalm-param  pure-callable(TValue,TKey):TNewValue $callback
+     * @psalm-param  callable(TValue,TKey):TNewValue $callback
      * @psalm-return MapInterface<TKey,TNewValue>
      */
     public function map(callable $callback): MapInterface
     {
         $data = [];
         foreach ($this->data as $key => $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $data[$key] = $callback($value, $key);
         }
 
@@ -326,6 +356,10 @@ abstract class Map extends Array_ implements MapInterface
         $filtered = $unfiltered = [];
 
         foreach ($this->data as $key => $element) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if ($callback($element)) {
                 $filtered[$key] = $element;
                 continue;
@@ -344,7 +378,7 @@ abstract class Map extends Array_ implements MapInterface
 
     /**
      * @template TGroup of non-empty-string
-     * @psalm-param pure-callable(TValue):TGroup $callback
+     * @psalm-param callable(TValue):TGroup $callback
      *
      * @psalm-return MapInterface<TGroup,MapInterface<TKey,TValue>>
      */
@@ -356,6 +390,10 @@ abstract class Map extends Array_ implements MapInterface
         $groups = new GenericMap([]);
 
         foreach ($this->data as $key => $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $groupIdentifier = $callback($value);
             try {
                 $group = $groups->get($groupIdentifier);
@@ -411,6 +449,10 @@ abstract class Map extends Array_ implements MapInterface
         $sorter   = $sorter ?? $this->keyComparator();
         $data     = $this->data;
         $instance = clone $this;
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         uksort($data, $sorter);
         $instance->data = $data;
 
@@ -429,7 +471,7 @@ abstract class Map extends Array_ implements MapInterface
 
     /**
      * @template TNewKey of string
-     * @param pure-callable(TKey,TValue):TNewKey $keyGenerator
+     * @param callable(TKey,TValue):TNewKey $keyGenerator
      *
      * @return MapInterface<TNewKey,TValue>
      * @throws RuntimeException if a new key is being generated more than once.
@@ -440,6 +482,10 @@ abstract class Map extends Array_ implements MapInterface
         $exchanged = new GenericMap();
 
         foreach ($this->data as $key => $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $newKey = $keyGenerator($key, $value);
             if ($exchanged->has($newKey)) {
                 throw new RuntimeException(sprintf(

--- a/src/MapInterface.php
+++ b/src/MapInterface.php
@@ -20,7 +20,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * Filters out all values not matched by the callback.
      * This method is the equivalent of `array_filter`.
      *
-     * @psalm-param  pure-callable(TValue,TKey):bool $callback
+     * @psalm-param  callable(TValue,TKey):bool $callback
      * @psalm-return MapInterface<TKey,TValue>
      */
     public function filter(callable $callback): MapInterface;
@@ -29,7 +29,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * Sorts the items by using either the given callback or the native `SORT_NATURAL` logic of PHP.
      * This method is the equivalent of `sort`/`usort`.
      *
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $callback
+     * @psalm-param  (callable(TValue,TValue):int)|null $callback
      * @psalm-return MapInterface<TKey,TValue>
      */
     public function sort(?callable $callback = null): MapInterface;
@@ -51,7 +51,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_diff`.
      *
      * @psalm-param  MapInterface<TKey,TValue> $other
-     * @psalm-param  (pure-callable(TKey,TKey):int)|null $keyComparator
+     * @psalm-param  (callable(TKey,TKey):int)|null $keyComparator
      * @psalm-return MapInterface<TKey,TValue>
      */
     public function diffKeys(MapInterface $other, ?callable $keyComparator = null): MapInterface;
@@ -61,7 +61,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_map`.
      *
      * @template     TNewValue
-     * @psalm-param  pure-callable(TValue,TKey):TNewValue $callback
+     * @psalm-param  callable(TValue,TKey):TNewValue $callback
      * @psalm-return MapInterface<TKey,TNewValue>
      */
     public function map(callable $callback): MapInterface;
@@ -74,7 +74,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_intersect`.
      *
      * @psalm-param  MapInterface<TKey,TValue> $other
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param  (callable(TValue,TValue):int)|null $valueComparator
      * @psalm-return MapInterface<TKey,TValue>
      */
     public function intersect(MapInterface $other, ?callable $valueComparator = null): MapInterface;
@@ -87,7 +87,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_diff`.
      *
      * @psalm-param  MapInterface<TKey,TValue> $other
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param  (callable(TValue,TValue):int)|null $valueComparator
      * @psalm-return MapInterface<TKey,TValue>
      */
     public function diff(MapInterface $other, ?callable $valueComparator = null): MapInterface;
@@ -97,7 +97,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * The items are being sorted by using the provided sorter. In case there is no sorter provided, the values
      * are just passed in the order they werestored in this map.
      *
-     * @psalm-param (pure-callable(TValue,TValue):int)|null $sorter
+     * @psalm-param (callable(TValue,TValue):int)|null $sorter
      * @psalm-return OrderedListInterface<TValue>
      */
     public function toOrderedList(?callable $sorter = null): OrderedListInterface;
@@ -163,7 +163,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      *
      * @psalm-param MapInterface<TKey,TValue> $other
      * @psalm-return MapInterface<TKey,TValue>
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param  (callable(TValue,TValue):int)|null $valueComparator
      */
     public function intersectAssoc(MapInterface $other, ?callable $valueComparator = null): MapInterface;
 
@@ -174,7 +174,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      *
      * @psalm-param MapInterface<TKey,TValue> $other
      * @psalm-return MapInterface<TKey,TValue>
-     * @psalm-param  (pure-callable(TKey,TKey):int)|null $keyComparator
+     * @psalm-param  (callable(TKey,TKey):int)|null $keyComparator
      */
     public function intersectUsingKeys(MapInterface $other, ?callable $keyComparator = null): MapInterface;
 
@@ -186,8 +186,8 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_intersect_assoc`/`array_intersect_uassoc`/`array_intersect_key`/`array_intersect_ukey`.
      *
      * @psalm-param MapInterface<TKey,TValue> $other
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $valueComparator
-     * @psalm-param  (pure-callable(TKey,TKey):int)|null $keyComparator
+     * @psalm-param  (callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param  (callable(TKey,TKey):int)|null $keyComparator
      * @psalm-return MapInterface<TKey,TValue>
      */
     public function intersectUserAssoc(
@@ -207,7 +207,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
     /**
      * Partitions the current map into those items which are filtered by the callback and those which don't.
      *
-     * @psalm-param pure-callable(TValue):bool $callback
+     * @psalm-param callable(TValue):bool $callback
      * @psalm-return array{0:MapInterface<TKey,TValue>,1:MapInterface<TKey,TValue>}
      */
     public function partition(callable $callback): array;
@@ -216,7 +216,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * Groups the items of this object by using the callback.
      *
      * @template TGroup of non-empty-string
-     * @psalm-param pure-callable(TValue):TGroup $callback
+     * @psalm-param callable(TValue):TGroup $callback
      *
      * @psalm-return MapInterface<TGroup,MapInterface<TKey,TValue>>
      */
@@ -235,7 +235,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * After the method has been executed properly, an `MappedErrorCollection` is being thrown so one can
      * see what item key actually failed executing the callback.
      *
-     * @param pure-callable(TValue,TKey):void $callback
+     * @param callable(TValue,TKey):void $callback
      * @throws MappedErrorCollection If an error occured during execution.
      */
     public function forAll(callable $callback): ForAllPromiseInterface;
@@ -243,7 +243,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
     /**
      * Sorts the map by sorting its keys.
      *
-     * @param (pure-callable(TKey,TKey):int)|null $sorter
+     * @param (callable(TKey,TKey):int)|null $sorter
      *
      * @psalm-return MapInterface<TKey,TValue>
      */
@@ -261,7 +261,7 @@ interface MapInterface extends ArrayInterface, JsonSerializable
      * Creates a new map where the keys of items might have been exchanged with another key.
      *
      * @template TNewKey of string
-     * @param pure-callable(TKey,TValue):TNewKey $keyGenerator
+     * @param callable(TKey,TValue):TNewKey $keyGenerator
      *
      * @return MapInterface<TNewKey,TValue>
      * @throws RuntimeException if a new key is being generated more than once.

--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -63,6 +63,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         $data = [];
         foreach ($this->data as $index => $value) {
             assert($index >= 0);
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $data[] = $callback($value, $index);
         }
 
@@ -97,6 +101,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
             return $instance;
         }
 
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         usort($data, $callback);
         $instance->data = $data;
 
@@ -109,12 +117,20 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
 
         $valueComparator = $valueComparator ?? $this->valueComparator();
 
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         $diff1 = array_udiff(
             $instance->toNativeArray(),
             $other->toNativeArray(),
             $valueComparator
         );
 
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         $diff2 = array_udiff(
             $other->toNativeArray(),
             $instance->toNativeArray(),
@@ -131,7 +147,11 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
 
     public function intersect(OrderedListInterface $other, ?callable $valueComparator = null): OrderedListInterface
     {
-        $instance       = clone $this;
+        $instance = clone $this;
+        /**
+         * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+         *                                    value here.
+         */
         $instance->data = array_values(array_uintersect(
             $instance->data,
             $other->toNativeArray(),
@@ -147,6 +167,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         $mapped   = [];
         foreach ($instance->data as $index => $value) {
             assert($index >= 0);
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $key          = $keyGenerator($value, $index);
             $mapped[$key] = $value;
         }
@@ -175,6 +199,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         $instance = clone $this;
         $filtered = [];
         foreach ($instance->data as $index => $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if (! $callback($value, $index)) {
                 continue;
             }
@@ -206,11 +234,19 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         $unified = new GenericMap([]);
 
         foreach ($instance->data as $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $identifier = $unificationIdentifierGenerator($value);
             try {
                 $unique = $unified->get($identifier);
 
                 if ($callback) {
+                    /**
+                     * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+                     *                                    value here.
+                     */
                     $unique = $callback($unique, $value);
                 }
             } catch (OutOfBoundsException $exception) {
@@ -248,24 +284,32 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
     }
 
     /**
-     * @psalm-param TValue|pure-callable(int):TValue $value
+     * @psalm-param TValue|callable(int):TValue $value
      * @psalm-return array<int,TValue>
      */
     private function createListFilledWithValues(int $start, int $amount, $value): array
     {
         $filled = [];
 
-        /** @var pure-callable(int):TValue $callable */
+        /** @var callable(int):TValue $callable */
         $callable = $value;
+        /**
+         * @psalm-suppress ImpureFunctionCall I was not aware that `is_callable` is impure...
+         */
         if (! is_callable($callable)) {
             /**
-             * @var pure-callable(int):TValue $callable
+             * @var callable(int):TValue $callable
              * @psalm-suppress MissingClosureReturnType We have to assume that the value contains the fill value.
+             * @return TValue
              */
             $callable = static fn () => $value;
         }
 
         for ($index = $start; $index < $amount; $index++) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $filled[$index] = $callable($index);
         }
 
@@ -288,6 +332,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
     public function find(callable $callback)
     {
         foreach ($this->data as $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if ($callback($value)) {
                 return $value;
             }
@@ -301,6 +349,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         $filtered = $unfiltered = [];
 
         foreach ($this->data as $element) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if ($callback($element)) {
                 $filtered[] = $element;
                 continue;
@@ -319,7 +371,7 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
 
     /**
      * @template TGroup of non-empty-string
-     * @psalm-param pure-callable(TValue):TGroup $callback
+     * @psalm-param callable(TValue):TGroup $callback
      *
      * @psalm-return MapInterface<TGroup,OrderedListInterface<TValue>>
      */
@@ -328,6 +380,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
         /** @var MapInterface<TGroup,OrderedListInterface<TValue>> $groups */
         $groups = new GenericMap([]);
         foreach ($this as $value) {
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             $groupName = $callback($value);
             if (! $groups->has($groupName)) {
                 $groups = $groups->put($groupName, new GenericOrderedList([$value]));
@@ -402,6 +458,10 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
     {
         foreach ($this->data as $index => $value) {
             assert($index >= 0);
+            /**
+             * @psalm-suppress ImpureFunctionCall Upstream projects have to ensure that they do not manipulate the
+             *                                    value here.
+             */
             if ($filter($value)) {
                 return $index;
             }

--- a/src/OrderedListInterface.php
+++ b/src/OrderedListInterface.php
@@ -36,7 +36,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * Filters out all values not matched by the callback.
      * This method is the equivalent of `array_filter`.
      *
-     * @psalm-param  pure-callable(TValue,int):bool $callback
+     * @psalm-param  callable(TValue,int):bool $callback
      * @psalm-return OrderedListInterface<TValue>
      */
     public function filter(callable $callback): OrderedListInterface;
@@ -45,7 +45,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * Sorts the items by using either the given callback or the native `SORT_NATURAL` logic of PHP.
      * This method is the equivalent of `sort`/`usort`.
      *
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $callback
+     * @psalm-param  (callable(TValue,TValue):int)|null $callback
      * @psalm-return OrderedListInterface<TValue>
      */
     public function sort(?callable $callback = null): OrderedListInterface;
@@ -65,7 +65,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_map`.
      *
      * @template     TNewValue
-     * @psalm-param  pure-callable(TValue,0|positive-int):TNewValue $callback
+     * @psalm-param  callable(TValue,0|positive-int):TNewValue $callback
      * @psalm-return OrderedListInterface<TNewValue>
      */
     public function map(callable $callback): OrderedListInterface;
@@ -78,7 +78,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_intersect`.
      *
      * @psalm-param  OrderedListInterface<TValue> $other
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param  (callable(TValue,TValue):int)|null $valueComparator
      * @psalm-return OrderedListInterface<TValue>
      */
     public function intersect(OrderedListInterface $other, ?callable $valueComparator = null): OrderedListInterface;
@@ -91,7 +91,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * This method is the equivalent of `array_diff`.
      *
      * @psalm-param  OrderedListInterface<TValue> $other
-     * @psalm-param  (pure-callable(TValue,TValue):int)|null $valueComparator
+     * @psalm-param  (callable(TValue,TValue):int)|null $valueComparator
      * @psalm-return OrderedListInterface<TValue>
      */
     public function diff(OrderedListInterface $other, ?callable $valueComparator = null): OrderedListInterface;
@@ -100,7 +100,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * Creates a map of this ordered list by using the provided key generator to generate dedicated keys for each item.
      *
      * @template TKeyForMap of non-empty-string
-     * @psalm-param  pure-callable(TValue,0|positive-int):TKeyForMap $keyGenerator
+     * @psalm-param  callable(TValue,0|positive-int):TKeyForMap $keyGenerator
      * @psalm-return MapInterface<TKeyForMap,TValue>
      */
     public function toMap(callable $keyGenerator): MapInterface;
@@ -120,8 +120,8 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * of a value. If not, a simple hashing strategy is being applied to identify identical values from this list.
      * In case a callback is provided, all duplications are being passed to that callback so one keep track of these.
      *
-     * @psalm-param (pure-callable(TValue):non-empty-string)|null $unificationIdentifierGenerator
-     * @psalm-param (pure-callable(TValue,TValue):TValue)|null $callback This callback is called for duplications only.
+     * @psalm-param (callable(TValue):non-empty-string)|null $unificationIdentifierGenerator
+     * @psalm-param (callable(TValue,TValue):TValue)|null $callback This callback is called for duplications only.
      * @psalm-return OrderedListInterface<TValue>
      */
     public function unify(
@@ -137,7 +137,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      *
      * @throws InvalidArgumentException if start index does is not fitting in the current list state.
      *
-     * @psalm-param TValue|pure-callable(int):TValue $value
+     * @psalm-param TValue|callable(int):TValue $value
      * @psalm-return OrderedListInterface<TValue>
      */
     public function fill(int $startIndex, int $amount, $value): OrderedListInterface;
@@ -164,7 +164,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * returning that match.
      * In case there are multiple elements matching the callback, only the first item will be returned.
      *
-     * @psalm-param pure-callable(TValue):bool $callback
+     * @psalm-param callable(TValue):bool $callback
      * @psalm-return TValue
      * @throws OutOfBoundsException if value could not be found with provided callback.
      */
@@ -173,7 +173,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
     /**
      * Partitions the current list into those items which are filtered by the callback and those which don't.
      *
-     * @param pure-callable(TValue $value):bool $callback
+     * @param callable(TValue $value):bool $callback
      *
      * @psalm-return array{0:OrderedListInterface<TValue>,1:OrderedListInterface<TValue>}
      */
@@ -183,7 +183,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * Groups the items by using the callback.
      *
      * @template TGroup of non-empty-string
-     * @psalm-param pure-callable(TValue):TGroup $callback
+     * @psalm-param callable(TValue):TGroup $callback
      *
      * @psalm-return MapInterface<TGroup,OrderedListInterface<TValue>>
      */
@@ -243,7 +243,7 @@ interface OrderedListInterface extends ArrayInterface, JsonSerializable
      * being returned and the iteration stops.
      * If no item matches the filter, `null` is being returned.
      *
-     * @param pure-callable(TValue):bool $filter
+     * @param callable(TValue):bool $filter
      *
      * @return 0|positive-int|null
      */

--- a/tests/GenericMapTest.php
+++ b/tests/GenericMapTest.php
@@ -934,7 +934,6 @@ final class GenericMapTest extends TestCase
         $errorCollection = null;
 
         try {
-            /** @psalm-suppress InvalidArgument We do want to pass an impure method here for testing purposes */
             $map->forAll($callable)->execute();
         } catch (MappedErrorCollection $errorCollection) {
         }
@@ -965,7 +964,6 @@ final class GenericMapTest extends TestCase
         $errorCollection = null;
 
         try {
-            /** @psalm-suppress InvalidArgument We do want to pass an impure method here for testing purposes */
             $map->forAll($callable)->stopOnError()->execute();
         } catch (MappedErrorCollection $errorCollection) {
         }

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -564,7 +564,6 @@ final class GenericOrderedListTest extends TestCase
 
         /**
          * @psalm-suppress UnusedMethodCall
-         * @psalm-suppress InvalidArgument We do explicitly pass impure callable here to track usages
          */
         $list->unify(null, static function (int $duplicate, int $number) use (&$callbackCalled): int {
             self::assertEquals($duplicate, $number);


### PR DESCRIPTION
It is almost impossible to ensure purity and in some cases that also makes no sense. Especially when it comes to mappings, purity is impossible and therefore, dropping this in a bugfix release might suffice.
