### PR TITLE
Allow random permutations without restrictions

### DIFF
--- a/src/OrderedList.php
+++ b/src/OrderedList.php
@@ -482,10 +482,7 @@ abstract class OrderedList extends Array_ implements OrderedListInterface
 
         $data = $this->data;
 
-        do {
-            shuffle($data);
-        } while ($this->data === $data);
-
+        shuffle($data);
         $instance       = clone $this;
         $instance->data = $data;
 

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -28,6 +28,7 @@ use function md5;
 use function mt_rand;
 use function range;
 use function spl_object_hash;
+use function sprintf;
 use function strlen;
 use function strnatcmp;
 
@@ -1476,15 +1477,29 @@ final class GenericOrderedListTest extends TestCase
 
     public function testWillShuffleValuesInList(): void
     {
-        $list = new GenericOrderedList([
-            1,
-            2,
-            3,
-        ]);
+        $values = [1, 2, 3];
+        $list   = new GenericOrderedList($values);
 
-        $list2 = $list->shuffle();
-        self::assertSame([1, 2, 3], $list->toNativeArray());
+        $maximumShuffleAttempts = 10;
+        $shuffledSameCount      = 0;
+
+        do {
+            $list2 = $list->shuffle();
+            if ($list2->toNativeArray() === $values) {
+                $shuffledSameCount++;
+                self::assertLessThan(
+                    $maximumShuffleAttempts,
+                    $shuffledSameCount,
+                    sprintf('The shuffle did not change the order after "%d" attempts.', $maximumShuffleAttempts),
+                );
+                continue;
+            }
+
+            break;
+        } while ($shuffledSameCount < $maximumShuffleAttempts);
+
         self::assertNotSame($list, $list2);
-        self::assertNotSame([1, 2, 3], $list2->toNativeArray());
+        self::assertEqualsCanonicalizing($values, $list2->toNativeArray());
+        self::assertNotSame($values, $list2->toNativeArray());
     }
 }

--- a/tests/GenericOrderedListTest.php
+++ b/tests/GenericOrderedListTest.php
@@ -1485,6 +1485,7 @@ final class GenericOrderedListTest extends TestCase
 
         do {
             $list2 = $list->shuffle();
+            /** @psalm-suppress TypeDoesNotContainType No clue why this is happening but for now we are suppressing */
             if ($list2->toNativeArray() === $values) {
                 $shuffledSameCount++;
                 self::assertLessThan(


### PR DESCRIPTION
In the initial PR, I prevented `shuffle` from returning the same value as the initial value. Since this might not be the expected outcome, I removed this behavior. Especially as that would prevent use-cases in real-world projects which want to use the `shuffle` method to i.e. load balance between multiple hostnames as the configured order would never be a result after using `shuffle` which basically prevents a specific order from being used at any time.